### PR TITLE
Modify source URLs to download from a verifiable address via HTTPS

### DIFF
--- a/sublime-text.spec
+++ b/sublime-text.spec
@@ -18,9 +18,9 @@ URL:     http://sublimetext.com
 ExclusiveArch: i686 x86_64
 
 %ifarch i686
-Source0: http://c758482.r82.cf2.rackcdn.com/sublime_text_%{major_version}_build_%{build_version}_x32.tar.bz2
+Source0: https://download.sublimetext.com/sublime_text_%{major_version}_build_%{build_version}_x32.tar.bz2
 %else
-Source0: http://c758482.r82.cf2.rackcdn.com/sublime_text_%{major_version}_build_%{build_version}_x64.tar.bz2
+Source0: https://download.sublimetext.com/sublime_text_%{major_version}_build_%{build_version}_x64.tar.bz2
 %endif
 Source1: sublime_text.desktop
 Source2: subl


### PR DESCRIPTION
Thanks for creating this! I made this small modification for my own install as I wanted a URL that I could easily determine was a good source -- when attempting to download the tarball from Sublime's website it uses https://download.sublimetext.com as the source, so it seems that we should do the same.

This should improve trust for the RPM and means that if he ever changes CDN we will not need to worry about that.
